### PR TITLE
[#10] refactor/10 User 도메인 객체와 엔티티 분리

### DIFF
--- a/src/main/java/com/flab/coongyaboard/auth/domain/User.java
+++ b/src/main/java/com/flab/coongyaboard/auth/domain/User.java
@@ -2,22 +2,16 @@ package com.flab.coongyaboard.auth.domain;
 
 import com.flab.coongyaboard.auth.entity.UserEntity;
 
-import java.time.LocalDateTime;
-
 public class User {
 
-    private final Long id;
     private final String email;
     private final String nickname;
     private final String password;
-    private final LocalDateTime createdAt;
 
-    private User(Long id, String email, String nickname, String password, LocalDateTime createdAt) {
-        this.id = id;
+    private User(String email, String nickname, String password) {
         this.email = email;
         this.nickname = nickname;
         this.password = password;
-        this.createdAt = createdAt;
     }
 
     public static User create(String email, String nickname, String password) {
@@ -31,10 +25,26 @@ public class User {
             throw new RuntimeException("password is empty");
         }
 
-        return new User(null, email, nickname, password, null);
+        return new User(email, nickname, password);
     }
 
     public UserEntity toEntity() {
-        return new UserEntity(this.id, this.email, this.nickname, this.password, this.createdAt);
+        return new UserEntity(null, this.email, this.nickname, this.password, null);
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (object == null || getClass() != object.getClass()) return false;
+
+        User user = (User) object;
+        return email.equals(user.email) && nickname.equals(user.nickname) && password.equals(user.password);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = email.hashCode();
+        result = 31 * result + nickname.hashCode();
+        result = 31 * result + password.hashCode();
+        return result;
     }
 }

--- a/src/main/java/com/flab/coongyaboard/auth/domain/User.java
+++ b/src/main/java/com/flab/coongyaboard/auth/domain/User.java
@@ -1,21 +1,40 @@
 package com.flab.coongyaboard.auth.domain;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import com.flab.coongyaboard.auth.entity.UserEntity;
 
 import java.time.LocalDateTime;
 
-@Getter
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
 public class User {
 
-    private Long id;
-    private String email;
-    private String nickname;
-    private String password;
-    private LocalDateTime createdAt;
+    private final Long id;
+    private final String email;
+    private final String nickname;
+    private final String password;
+    private final LocalDateTime createdAt;
+
+    private User(Long id, String email, String nickname, String password, LocalDateTime createdAt) {
+        this.id = id;
+        this.email = email;
+        this.nickname = nickname;
+        this.password = password;
+        this.createdAt = createdAt;
+    }
+
+    public static User create(String email, String nickname, String password) {
+        if (email == null || email.isEmpty()) {
+          throw new RuntimeException("email is empty");
+        }
+        if (nickname == null || nickname.isEmpty()) {
+            throw new RuntimeException("nickname is empty");
+        }
+        if (password == null || password.isEmpty()) {
+            throw new RuntimeException("password is empty");
+        }
+
+        return new User(null, email, nickname, password, null);
+    }
+
+    public UserEntity toEntity() {
+        return new UserEntity(this.id, this.email, this.nickname, this.password, this.createdAt);
+    }
 }

--- a/src/main/java/com/flab/coongyaboard/auth/entity/UserEntity.java
+++ b/src/main/java/com/flab/coongyaboard/auth/entity/UserEntity.java
@@ -1,0 +1,20 @@
+package com.flab.coongyaboard.auth.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserEntity {
+    private Long id;
+    private String email;
+    private String nickname;
+    private String password;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/flab/coongyaboard/auth/entity/UserEntity.java
+++ b/src/main/java/com/flab/coongyaboard/auth/entity/UserEntity.java
@@ -1,5 +1,6 @@
 package com.flab.coongyaboard.auth.entity;
 
+import com.flab.coongyaboard.auth.domain.User;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -17,4 +18,8 @@ public class UserEntity {
     private String nickname;
     private String password;
     private LocalDateTime createdAt;
+
+    public User toDomain() {
+        return User.create(this.email, this.nickname, this.password);
+    }
 }

--- a/src/main/java/com/flab/coongyaboard/auth/repository/UserMapper.java
+++ b/src/main/java/com/flab/coongyaboard/auth/repository/UserMapper.java
@@ -1,12 +1,13 @@
 package com.flab.coongyaboard.auth.repository;
 
-import com.flab.coongyaboard.auth.domain.User;
 import com.flab.coongyaboard.auth.entity.UserEntity;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
 @Mapper
 public interface UserMapper {
+
+    UserEntity findByEmail(@Param("email") String email);
 
     UserEntity findByEmailForUpdate(@Param("email") String email);
 

--- a/src/main/java/com/flab/coongyaboard/auth/repository/UserMapper.java
+++ b/src/main/java/com/flab/coongyaboard/auth/repository/UserMapper.java
@@ -1,15 +1,16 @@
 package com.flab.coongyaboard.auth.repository;
 
 import com.flab.coongyaboard.auth.domain.User;
+import com.flab.coongyaboard.auth.entity.UserEntity;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
 @Mapper
 public interface UserMapper {
 
-    User findByEmailForUpdate(@Param("email") String email);
+    UserEntity findByEmailForUpdate(@Param("email") String email);
 
     boolean existsByEmail(@Param("email") String email);
 
-    void insert(User user);
+    void insert(UserEntity userEntity);
 }

--- a/src/main/java/com/flab/coongyaboard/auth/repository/UserRepository.java
+++ b/src/main/java/com/flab/coongyaboard/auth/repository/UserRepository.java
@@ -1,0 +1,16 @@
+package com.flab.coongyaboard.auth.repository;
+
+import com.flab.coongyaboard.auth.domain.User;
+
+import java.util.Optional;
+
+public interface UserRepository {
+
+    Optional<User> findByEmail(String email);
+
+    Optional<User> findByEmailForUpdate(String email);
+
+    boolean existsByEmail(String email);
+
+    void save(User user);
+}

--- a/src/main/java/com/flab/coongyaboard/auth/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/flab/coongyaboard/auth/repository/UserRepositoryImpl.java
@@ -1,0 +1,43 @@
+package com.flab.coongyaboard.auth.repository;
+
+import com.flab.coongyaboard.auth.domain.User;
+import com.flab.coongyaboard.auth.entity.UserEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class UserRepositoryImpl implements UserRepository {
+
+    private final UserMapper userMapper;
+
+    @Override
+    public Optional<User> findByEmail(String email) {
+        UserEntity userEntity = userMapper.findByEmail(email);
+        if (userEntity == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(userEntity.toDomain());
+    }
+
+    @Override
+    public Optional<User> findByEmailForUpdate(String email) {
+        UserEntity userEntity = userMapper.findByEmailForUpdate(email);
+        if (userEntity == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(userEntity.toDomain());
+    }
+
+    @Override
+    public boolean existsByEmail(String email) {
+        return userMapper.existsByEmail(email);
+    }
+
+    @Override
+    public void save(User user) {
+        userMapper.insert(user.toEntity());
+    }
+}

--- a/src/main/java/com/flab/coongyaboard/auth/service/AuthService.java
+++ b/src/main/java/com/flab/coongyaboard/auth/service/AuthService.java
@@ -2,9 +2,8 @@ package com.flab.coongyaboard.auth.service;
 
 import com.flab.coongyaboard.auth.domain.User;
 import com.flab.coongyaboard.auth.dto.SignupRequest;
-import com.flab.coongyaboard.auth.entity.UserEntity;
 import com.flab.coongyaboard.auth.exception.DuplicateEmailException;
-import com.flab.coongyaboard.auth.repository.UserMapper;
+import com.flab.coongyaboard.auth.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -14,7 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class AuthService {
 
-    private final UserMapper userMapper;
+    private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
 
     @Transactional
@@ -22,13 +21,13 @@ public class AuthService {
 
         String encodedPassword = passwordEncoder.encode(request.getPassword());
 
-        userMapper.findByEmailForUpdate(request.getEmail());
+        userRepository.findByEmailForUpdate(request.getEmail());
 
-        if (userMapper.existsByEmail(request.getEmail())) {
+        if (userRepository.existsByEmail(request.getEmail())) {
             throw new DuplicateEmailException();
         }
 
         User user = User.create(request.getEmail(), request.getNickname(), encodedPassword);
-        userMapper.insert(user.toEntity());
+        userRepository.save(user);
     }
 }

--- a/src/main/java/com/flab/coongyaboard/auth/service/AuthService.java
+++ b/src/main/java/com/flab/coongyaboard/auth/service/AuthService.java
@@ -1,7 +1,7 @@
 package com.flab.coongyaboard.auth.service;
 
-import com.flab.coongyaboard.auth.domain.User;
 import com.flab.coongyaboard.auth.dto.SignupRequest;
+import com.flab.coongyaboard.auth.entity.UserEntity;
 import com.flab.coongyaboard.auth.exception.DuplicateEmailException;
 import com.flab.coongyaboard.auth.repository.UserMapper;
 import lombok.RequiredArgsConstructor;
@@ -27,12 +27,11 @@ public class AuthService {
             throw new DuplicateEmailException();
         }
 
-        User user = User.builder()
-                .email(request.getEmail())
-                .nickname(request.getNickname())
-                .password(encodedPassword)
-                .build();
+        UserEntity userEntity = new UserEntity();
+        userEntity.setEmail(request.getEmail());
+        userEntity.setNickname(request.getNickname());
+        userEntity.setPassword(encodedPassword);
 
-        userMapper.insert(user);
+        userMapper.insert(userEntity);
     }
 }

--- a/src/main/java/com/flab/coongyaboard/auth/service/AuthService.java
+++ b/src/main/java/com/flab/coongyaboard/auth/service/AuthService.java
@@ -1,5 +1,6 @@
 package com.flab.coongyaboard.auth.service;
 
+import com.flab.coongyaboard.auth.domain.User;
 import com.flab.coongyaboard.auth.dto.SignupRequest;
 import com.flab.coongyaboard.auth.entity.UserEntity;
 import com.flab.coongyaboard.auth.exception.DuplicateEmailException;
@@ -27,11 +28,7 @@ public class AuthService {
             throw new DuplicateEmailException();
         }
 
-        UserEntity userEntity = new UserEntity();
-        userEntity.setEmail(request.getEmail());
-        userEntity.setNickname(request.getNickname());
-        userEntity.setPassword(encodedPassword);
-
-        userMapper.insert(userEntity);
+        User user = User.create(request.getEmail(), request.getNickname(), encodedPassword);
+        userMapper.insert(user.toEntity());
     }
 }

--- a/src/main/resources/mappers/UserMapper.xml
+++ b/src/main/resources/mappers/UserMapper.xml
@@ -5,15 +5,7 @@
 
 <mapper namespace="com.flab.coongyaboard.auth.repository.UserMapper">
 
-    <resultMap id="UserResultMap" type="com.flab.coongyaboard.auth.domain.User">
-        <id     column="id"         property="id"/>
-        <result column="email"      property="email"/>
-        <result column="nickname"   property="nickname"/>
-        <result column="password"   property="password"/>
-        <result column="created_at" property="createdAt"/>
-    </resultMap>
-
-    <select id="findByEmailForUpdate" resultMap="UserResultMap">
+    <select id="findByEmailForUpdate" resultType="com.flab.coongyaboard.auth.entity.UserEntity">
         SELECT id, email, nickname, password, created_at
         FROM user
         WHERE email = #{email}
@@ -29,7 +21,7 @@
     </select>
 
     <insert id="insert"
-            parameterType="com.flab.coongyaboard.auth.domain.User"
+            parameterType="com.flab.coongyaboard.auth.entity.UserEntity"
             useGeneratedKeys="true"
             keyProperty="id">
         INSERT INTO user (email, nickname, password)

--- a/src/test/java/com/flab/coongyaboard/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/flab/coongyaboard/auth/service/AuthServiceTest.java
@@ -1,7 +1,7 @@
 package com.flab.coongyaboard.auth.service;
 
-import com.flab.coongyaboard.auth.domain.User;
 import com.flab.coongyaboard.auth.dto.SignupRequest;
+import com.flab.coongyaboard.auth.entity.UserEntity;
 import com.flab.coongyaboard.auth.exception.DuplicateEmailException;
 import com.flab.coongyaboard.auth.repository.UserMapper;
 import org.junit.jupiter.api.DisplayName;
@@ -44,8 +44,8 @@ class AuthServiceTest {
     void signup_success_when_email_not_duplicate() throws Exception {
         // given
         String email = "user@example.com";
-        String password = "Password123!";
-        String encodedPassword = "Encoded123!";
+        String password = "password123!";
+        String encodedPassword = "encoded123!";
         String nickname = "닉네임";
         SignupRequest request = createSignupRequest(email, password, nickname);
 
@@ -61,10 +61,10 @@ class AuthServiceTest {
         verify(userMapper).findByEmailForUpdate(email);
         verify(userMapper).existsByEmail(email);
 
-        ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+        ArgumentCaptor<UserEntity> userCaptor = ArgumentCaptor.forClass(UserEntity.class);
         verify(userMapper).insert(userCaptor.capture());
 
-        User savedUser = userCaptor.getValue();
+        UserEntity savedUser = userCaptor.getValue();
         assertThat(savedUser.getEmail()).isEqualTo(email);
         assertThat(savedUser.getNickname()).isEqualTo(nickname);
         assertThat(savedUser.getPassword()).isEqualTo(encodedPassword);
@@ -75,8 +75,8 @@ class AuthServiceTest {
     void signup_fail_when_email_duplicate() {
         // given
         String email = "user@example.com";
-        String password = "Password123!";
-        String encodedPassword = "Encoded123!";
+        String password = "password123!";
+        String encodedPassword = "encoded123!";
         String nickname = "닉네임";
         SignupRequest request = createSignupRequest(email, password, nickname);
 
@@ -90,6 +90,6 @@ class AuthServiceTest {
         verify(passwordEncoder).encode(password);
         verify(userMapper).findByEmailForUpdate(email);
         verify(userMapper).existsByEmail(email);
-        verify(userMapper, never()).insert(any(User.class));
+        verify(userMapper, never()).insert(any(UserEntity.class));
     }
 }

--- a/src/test/java/com/flab/coongyaboard/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/flab/coongyaboard/auth/service/AuthServiceTest.java
@@ -1,9 +1,10 @@
 package com.flab.coongyaboard.auth.service;
 
+import com.flab.coongyaboard.auth.domain.User;
 import com.flab.coongyaboard.auth.dto.SignupRequest;
 import com.flab.coongyaboard.auth.entity.UserEntity;
 import com.flab.coongyaboard.auth.exception.DuplicateEmailException;
-import com.flab.coongyaboard.auth.repository.UserMapper;
+import com.flab.coongyaboard.auth.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -23,7 +24,7 @@ import static org.mockito.Mockito.*;
 class AuthServiceTest {
 
     @Mock
-    private UserMapper userMapper;
+    private UserRepository userRepository;
 
     @Mock
     private PasswordEncoder passwordEncoder;
@@ -50,7 +51,7 @@ class AuthServiceTest {
         SignupRequest request = createSignupRequest(email, password, nickname);
 
         when(passwordEncoder.encode(password)).thenReturn(encodedPassword);
-        when(userMapper.existsByEmail(email)).thenReturn(false);
+        when(userRepository.existsByEmail(email)).thenReturn(false);
 
         // when
         authService.signup(request);
@@ -58,16 +59,17 @@ class AuthServiceTest {
         // then
         verify(passwordEncoder).encode(password);
 
-        verify(userMapper).findByEmailForUpdate(email);
-        verify(userMapper).existsByEmail(email);
+        verify(userRepository).findByEmailForUpdate(email);
+        verify(userRepository).existsByEmail(email);
 
-        ArgumentCaptor<UserEntity> userCaptor = ArgumentCaptor.forClass(UserEntity.class);
-        verify(userMapper).insert(userCaptor.capture());
+        ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(userCaptor.capture());
 
-        UserEntity savedUser = userCaptor.getValue();
-        assertThat(savedUser.getEmail()).isEqualTo(email);
-        assertThat(savedUser.getNickname()).isEqualTo(nickname);
-        assertThat(savedUser.getPassword()).isEqualTo(encodedPassword);
+        User savedUser = userCaptor.getValue();
+        UserEntity userEntity = savedUser.toEntity();
+        assertThat(userEntity.getEmail()).isEqualTo(email);
+        assertThat(userEntity.getNickname()).isEqualTo(nickname);
+        assertThat(userEntity.getPassword()).isEqualTo(encodedPassword);
     }
 
     @Test
@@ -81,15 +83,15 @@ class AuthServiceTest {
         SignupRequest request = createSignupRequest(email, password, nickname);
 
         when(passwordEncoder.encode(password)).thenReturn(encodedPassword);
-        when(userMapper.existsByEmail(email)).thenReturn(true);
+        when(userRepository.existsByEmail(email)).thenReturn(true);
 
         // when & then
         assertThatThrownBy(() -> authService.signup(request))
                 .isInstanceOf(DuplicateEmailException.class);
 
         verify(passwordEncoder).encode(password);
-        verify(userMapper).findByEmailForUpdate(email);
-        verify(userMapper).existsByEmail(email);
-        verify(userMapper, never()).insert(any(UserEntity.class));
+        verify(userRepository).findByEmailForUpdate(email);
+        verify(userRepository).existsByEmail(email);
+        verify(userRepository, never()).save(any(User.class));
     }
 }

--- a/src/test/java/com/flab/coongyaboard/config/SecurityConfigTest.java
+++ b/src/test/java/com/flab/coongyaboard/config/SecurityConfigTest.java
@@ -18,7 +18,7 @@ class SecurityConfigTest {
     @DisplayName("비밀번호 단방향 암호화 성공")
     void encodeAndMatches() {
         // given
-        String password = "Password123!";
+        String password = "password123!";
 
         // when
         String encodedPassword = passwordEncoder.encode(password);
@@ -27,6 +27,6 @@ class SecurityConfigTest {
         assertThat(encodedPassword).isNotBlank();
         assertThat(encodedPassword).isNotEqualTo(password);
         assertThat(passwordEncoder.matches(password, encodedPassword)).isTrue();
-        assertThat(passwordEncoder.matches("Password123@", encodedPassword)).isFalse();
+        assertThat(passwordEncoder.matches("password123@", encodedPassword)).isFalse();
     }
 }


### PR DESCRIPTION
안녕하세요.
User 도메인 객체와 엔티티를 분리하고 관련 로직을 수정했습니다.

1. User 도메인 객체를 불변 객체로 변경
2. User 도메인 객체의 생성자 접근 제한을 private으로 변경, 정적 팩토리 메서드로 필수값 검증 후 객체 생성, 기본 생성자와 빌더 패턴 제거
3. UserMapper의 parameterType, resultType을 UserEntity로 변경
4. User <-> UserEntity 변환 메서드 추가
5. 서비스 레이어가 도메인 객체에만 의존하도록 UserRepository 추가, UserRepository 구현체가 User, UserEntity 변환 및 UserMapper 호출하도록 수정
6. AuthService.signup() 수정
7. 테스트 코드 수정

리뷰 부탁드립니다.
감사합니다.